### PR TITLE
Add _Z_NO_COMPLETE_CD option

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -347,7 +347,7 @@ if [ -n "$BASH_VERSION" ]; then
   eval "_cd_z () { ${func:-_z_dirs}; (( \${#COMPREPLY} > 0 )) || _z_stack; }"
  }; __z_complete_cd; unset -f __z_complete_cd
 
- [[ "$_Z_NO_COMPLETE_CD" ]] || complete -o nospace -F _cd_z cd
+ [[ -n "$_Z_NO_COMPLETE_CD" ]] || complete -o nospace -F _cd_z cd
  return
 fi
 
@@ -413,5 +413,5 @@ if [[ "${ZSH_VERSION-0.0}" != [0-3].* ]]; then
   _wanted z expl 'z stack' _z_stack
  }
 
-  [[ "$_Z_NO_COMPLETE_CD" ]] || compdef _cd_z cd
+  [ "$_Z_NO_COMPLETE_CD" ] || compdef _cd_z cd
 fi


### PR DESCRIPTION
I don't like getting 'z' completions for 'cd', because I often use cd[space][tab] to cd to the first subdirectory, so I added an option to disable that. Define _Z_NO_COMPLETE_CD to disable 'cd' completion, leave undefined for old behavior.
