### PR TITLE
Don't automatically start selection

### DIFF
--- a/src/z.interactive.zsh
+++ b/src/z.interactive.zsh
@@ -49,7 +49,6 @@ _z_stack () {
   done
   (( ${#qlist} == 0 )) && return 1
   compadd -d qlist -U -Q "$@" -- "${qlist[@]}"
-  compstate[insert]=menu
  fi
 }
 

--- a/z.sh
+++ b/z.sh
@@ -435,7 +435,6 @@ if [[ "${ZSH_VERSION-0.0}" != [0-3].* ]]; then
    done
    (( ${#qlist} == 0 )) && return 1
    compadd -d qlist -U -Q "$@" -- "${qlist[@]}"
-   compstate[insert]=menu
   fi
  }
 


### PR DESCRIPTION
Hello, I have `zstyle ':completion:*:default' menu select=1` set in my `.zshrc`, which allows me to start selecting the candidates at will rather than the comp system automatically starting it. Having `compstate[insert]=menu` in `z.sh` seemed to break this and candidates were being selected automatically, so I'm making this pull request as an attempt to fix it. However, I wasn't sure whether...
1. I am missing something and there is a way to preserve the behavior of `zstyle ':completion:*:default' menu select=1` without this pull request
2. I should update the README also. I didn't change the README because the plugin can be used in bash also, and didn't seem to make much sense to talk about zsh-specific features. I will certainly update it if that's better.

Commit description:

This change is made because the selection cannot be disabled even with:

```
zstyle ':completion:*:z' menu false
```

On the other hand, if users want to preserve the old automatic selection
behavior,

```
zstyle ':completion:*:z' menu yes
```

can be added to the .zshrc and have more flexible customization.
